### PR TITLE
Add server actions - component flow svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Please read the [setting up the project locally](https://docs.frameground.tech/d
 ![image](https://utfs.io/f/bbfc8452-5ba9-4a88-8808-a75ac2a35aee-r60jor.png)
 ![image](https://github.com/PhantomKnight287/frameground/assets/76196237/61af540a-68e8-4bbc-a20e-202b5cd1668c)
 
+## Server Actions - Component Flow
+
+[![Server Actions - Component Flow](https://nextjs.apidiagram.com/github/PhantomKnight287/frameground/diagram.svg)](https://nextjs.apidiagram.com/github/PhantomKnight287/frameground)
 
 ## Sponsors
 


### PR DESCRIPTION
Adds the React Server Actions to Frontend Component flow diagram to Readme. [Discord discussion.](https://discord.com/channels/752553802359505017/1240633132047401074/1256751294979248269)

My surveys across various developer circles concluded that having access to code flow between frontend components and server actions improves efficiency for onboarding, debugging, and development especially for contributors less familiar.

Hope this helps!

# Preview:
<img width="1079" alt="Screenshot 2024-07-01 at 12 43 04 PM" src="https://github.com/PhantomKnight287/frameground/assets/56985156/1bef57ef-59b4-44d0-8869-d0cc363dcb08">
